### PR TITLE
remove package after install in maven command

### DIFF
--- a/flow.groovy
+++ b/flow.groovy
@@ -1,7 +1,7 @@
 def devQAStaging() {
     env.PATH="${tool 'Maven 3.x'}/bin:${env.PATH}"
     stage 'Dev'
-    sh 'mvn clean install package'
+    sh 'mvn clean install'
     archive 'target/x.war'
   try {
         checkpoint('Archived war')


### PR DESCRIPTION
There's no reason to call package and install (particularly with package after install), since package is already part of the Maven default lifecycle and comes before install. 

See here: http://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
